### PR TITLE
fix middleware

### DIFF
--- a/router.go
+++ b/router.go
@@ -333,13 +333,13 @@ func (r *Router) Handle(method, path string, handle Handle) {
 		panic("handle must not be nil")
 	}
 
+	// Wrap with middleware first
+	handle = r.wrapMiddlewares(handle)
+
 	if r.SaveMatchedRoutePath {
 		varsCount++
 		handle = r.saveMatchedRoutePath(path, handle)
 	}
-
-	// Wrap with middleware
-	handle = r.wrapMiddlewares(handle)
 
 	if r.trees == nil {
 		r.trees = make(map[string]*node)

--- a/router_test.go
+++ b/router_test.go
@@ -1188,10 +1188,9 @@ func TestRouterMiddleware(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		// Middleware runs before SaveMatchedRoutePath is applied, so it won't see the matched route path
-		// But the handler should see it correctly
-		if middlewareParams.MatchedRoutePath() != "" {
-			t.Errorf("Middleware: expected empty matched route (runs before SaveMatchedRoutePath), got %q", middlewareParams.MatchedRoutePath())
+		// Middleware now runs after SaveMatchedRoutePath is applied, so it should see the matched route path
+		if middlewareParams.MatchedRoutePath() != "/route/:param" {
+			t.Errorf("Middleware: expected matched route '/route/:param', got %q", middlewareParams.MatchedRoutePath())
 		}
 		if handlerParams.MatchedRoutePath() != "/route/:param" {
 			t.Errorf("Handler: expected matched route '/route/:param', got %q", handlerParams.MatchedRoutePath())


### PR DESCRIPTION
# Fix Route Information Missing from OpenTelemetry Spans

## Problem

OpenTelemetry spans were not capturing route information (`http.route` attribute) even though:
- Router had `SaveMatchedRoutePath = true` configured correctly
- Route parameters were being captured (e.g., `environment_id=1`)  
- `ps.MatchedRoutePath()` was returning empty strings

## Root Cause

**Middleware execution order was incorrect** in httprouter. The OtelMiddleware was running **before** the route path information was added to the parameters.

**Previous execution order:**
1. Route matching finds handler
2. ❌ **OtelMiddleware runs** → gets params like `environment_id=1` but no `$matchedRoutePath`
3. `saveMatchedRoutePath` wrapper adds route path to params  
4. Actual handler runs

## Solution

Changed the middleware execution order in `httprouter/router.go` by moving middleware wrapping to occur **after** route path saving:

```go
// Before
if r.SaveMatchedRoutePath {
    handle = r.saveMatchedRoutePath(path, handle)
}
handle = r.wrapMiddlewares(handle)

// After  
handle = r.wrapMiddlewares(handle)
if r.SaveMatchedRoutePath {
    handle = r.saveMatchedRoutePath(path, handle)
}
```

**New execution order:**
1. Route matching finds handler
2. ✅ **OtelMiddleware runs** → gets complete params including route path
3. `saveMatchedRoutePath` wrapper adds route path to params
4. Actual handler runs

## Impact

✅ **Span names** now use route templates: `GET /v1/environments/:environment_id/object_types`  
✅ **Route attributes** are captured: `http.route = "/v1/environments/:environment_id/object_types"`  
✅ **Better span grouping** - requests to same route template are grouped together  
✅ **Improved observability** - easier to analyze API performance by route patterns

## Files Changed

- `httprouter/router.go` - Fixed middleware execution order 
- `gaia/libraries/otel/httprouter/middleware.go` - Updated span naming to use route templates when available
- `gaia/libraries/otel/httprouter/middleware_test.go` - Updated tests to expect route templates in span names
- `httprouter/router_test.go` - Updated middleware test to reflect new execution order 